### PR TITLE
Remove unused rx dependencies

### DIFF
--- a/bubblepicker/build.gradle
+++ b/bubblepicker/build.gradle
@@ -30,10 +30,6 @@ dependencies {
 
     compile files('libs/jbox2d-library-2.1.2.2.jar')
     compile files('libs/slf4j-api-1.7.22.jar')
-
-    compile 'io.reactivex:rxkotlin:0.60.0'
-    compile 'io.reactivex:rxandroid:1.2.0'
-    compile 'io.reactivex:rxjava:1.1.6'
 }
 repositories {
     mavenCentral()


### PR DESCRIPTION
First off, thanks for developing this solution. Struggling to get this effect to work with canvas, I was happy to run into this project.

This PR is to remove some dependencies that don't seem to be used anywhere in the project:

- rxkotlin
- rxandroid
- rxjava

After removing them, I ran the sample app, and it worked fine.

I had to remove these in my fork of the project because adding these library added ~20k methods to my project, forcing me to enable minification on my debug builds.